### PR TITLE
Feature/improve highlight

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -5,14 +5,12 @@
   "brackets": [
     ["{", "}"],
     ["[", "]"],
-    ["(", ")"],
-    ["<", ">"]
+    ["(", ")"]
   ],
   "autoClosingPairs": [
     { "open": "{", "close": "}" },
     { "open": "[", "close": "]" },
     { "open": "(", "close": ")" },
-    { "open": "<", "close": ">" },
     { "open": "'", "close": "'", "notIn": ["string", "comment"] },
     { "open": "\"", "close": "\"", "notIn": ["string"] },
     { "open": "`", "close": "`", "notIn": ["string", "comment"] }
@@ -23,8 +21,7 @@
     ["(", ")"],
     ["'", "'"],
     ["\"", "\""],
-    ["`", "`"],
-    ["<", ">"]
+    ["`", "`"]
   ],
   "folding": {
     "markers": {

--- a/snippets/snippets.code-snippets
+++ b/snippets/snippets.code-snippets
@@ -194,11 +194,11 @@
 		],
 		"description": "To create an interface"
 	},
-	"create TxContract": {
-		"prefix": "contract",
+	"create AssetScript": {
+		"prefix": "AssetScript",
 		"body": [
 			"// create contract:",
-			"Contract $1 {",
+			"AssetScript $1 {",
 				"\tevent $2($3)",
 				"\tpub fn $4() -> ($5)",
 				"\tpub fn $6() -> ($7)",

--- a/src/formatter/formatter.ts
+++ b/src/formatter/formatter.ts
@@ -30,7 +30,6 @@ export class FormatterProvider implements vscode.DocumentFormattingEditProvider 
       'emit',
       'struct',
       'TxScript',
-      'TxContract',
       'Contract',
       'AssetScript',
       'enum',

--- a/src/provider/hover/builtIn/keyword.ts
+++ b/src/provider/hover/builtIn/keyword.ts
@@ -74,8 +74,8 @@ export const keyword = [
     kind: 'keyword',
   },
   {
-    name: 'TxContract',
-    detail: 'Contract ContractName([mut] fieldN: <type>) [extends <InterfaceName>] { ... }',
+    name: 'AssetScript',
+    detail: 'AssetScript <ScriptName>([mut] fieldN: <type>) { ... }',
     kind: 'keyword',
   },
   {

--- a/syntaxes/ralph.tmLanguage.json
+++ b/syntaxes/ralph.tmLanguage.json
@@ -10,7 +10,8 @@
     { "include": "#keywords" },
     { "include": "#global" },
     { "include": "#number" },
-    { "include": "#constant" }
+    { "include": "#constant" },
+    { "include": "#variables" }
   ],
   "repository": {
     "comment": {
@@ -181,6 +182,28 @@
           "match": "\\b[A-Z][A-Za-z0-9]*\\b(?!!)"
         }
 
+      ]
+    },
+    "variables": {
+      "patterns": [
+        {
+          "match": "\\b([A-Za-z][A-Za-z0-9]*)\\s*:\\s*([A-Z][A-Za-z0-9]*)\\b",
+          "captures": {
+            "1": {
+              "name": "variable.parameter.ralph"
+            },
+            "2": {
+              "name": "entity.name.type.ralph"
+            }
+          }
+        },{
+          "match": "\\b([A-Za-z][A-Za-z0-9]*)\\s*=",
+          "captures": {
+            "1": {
+              "name": "variable.parameter.ralph"
+            }
+          }
+        }
       ]
     }
   }

--- a/syntaxes/ralph.tmLanguage.json
+++ b/syntaxes/ralph.tmLanguage.json
@@ -5,8 +5,9 @@
   "patterns": [
     { "include": "#comment" },
     { "include": "#imports" },
-    { "include": "#keywords" },
     { "include": "#types" },
+    { "include": "#storages" },
+    { "include": "#keywords" },
     { "include": "#global" },
     { "include": "#number" },
     { "include": "#constant" }
@@ -89,26 +90,26 @@
           "name": "keyword.function.ralph"
         },
         {
-          "match": "\\b(extends|Abstract|implements)\\b",
-          "name": "keyword.extends.ralph"
-        },
-        {
-          "match": "\\b(Interface)\\b",
-          "name": "keyword.Interface.ralph"
-        },
-        {
-          "match": "\\b(event|emit)\\b",
-          "name": "keyword.event.ralph"
+          "match": "\\b(emit)\\b",
+          "name": "keyword.emit.ralph"
         },
         {
           "match": "(@using|@unused)\\b",
           "name": "keyword.annotation.ralph"
         },
-        {
-          "match": "\\b(TxScript|TxContract|Contract|AssetScript|enum)\\b",
-          "name": "keyword.struct.ralph"
-        },
         { "include": "#operators" }
+      ]
+    },
+    "storages" : {
+      "patterns": [
+        {
+          "match": "\\b(Interface|TxScript|TxContract|Contract|AssetScript|enum|event)\\b",
+          "name": "storage.type.ralph"
+        },
+        {
+          "match": "\\b(extends|Abstract|implements)\\b",
+          "name": "storage.modifier.ralph"
+        }
       ]
     },
     "types": {
@@ -119,6 +120,18 @@
           "captures": {
             "1": {
               "name": "support.type.primitive.ralph"
+            }
+          }
+        },
+        {
+          "comment": "storage declarations",
+          "match": "\\b(Interface|TxScript|TxContract|Contract|AssetScript|enum|event)\\s+([A-Z][A-Za-z0-9]*)\\b",
+          "captures": {
+            "1": {
+              "name": "storage.type.ralph"
+            },
+            "2": {
+              "name": "entity.name.type.ralph"
             }
           }
         }
@@ -146,6 +159,9 @@
       "patterns": [
         {
           "include": "#global-functions"
+        },
+        {
+          "include": "#global-types"
         }
       ]
     },
@@ -155,6 +171,16 @@
           "match": "\\w*?\\!",
           "name": "support.function.builtIn.ralph"
         }
+      ]
+    },
+    "global-types": {
+      "patterns": [
+        {
+          "comment": "types",
+          "name": "entity.name.type.rust",
+          "match": "\\b[A-Z][A-Za-z0-9]*\\b(?!!)"
+        }
+
       ]
     }
   }

--- a/syntaxes/ralph.tmLanguage.json
+++ b/syntaxes/ralph.tmLanguage.json
@@ -103,7 +103,7 @@
     "storages" : {
       "patterns": [
         {
-          "match": "\\b(Interface|TxScript|TxContract|Contract|AssetScript|enum|event)\\b",
+          "match": "\\b(Interface|TxScript|Contract|AssetScript|enum|event)\\b",
           "name": "storage.type.ralph"
         },
         {
@@ -125,7 +125,7 @@
         },
         {
           "comment": "storage declarations",
-          "match": "\\b(Interface|TxScript|TxContract|Contract|AssetScript|enum|event)\\s+([A-Z][A-Za-z0-9]*)\\b",
+          "match": "\\b(Interface|TxScript|Contract|AssetScript|enum|event)\\s+([A-Z][A-Za-z0-9]*)\\b",
           "captures": {
             "1": {
               "name": "storage.type.ralph"

--- a/syntaxes/ralph.tmLanguage.json
+++ b/syntaxes/ralph.tmLanguage.json
@@ -7,6 +7,7 @@
     { "include": "#imports" },
     { "include": "#types" },
     { "include": "#storages" },
+    { "include": "#functions" },
     { "include": "#keywords" },
     { "include": "#global" },
     { "include": "#number" },
@@ -182,6 +183,21 @@
           "match": "\\b[A-Z][A-Za-z0-9]*\\b(?!!)"
         }
 
+      ]
+    },
+    "functions": {
+      "patterns": [
+        {
+          "match": "\\b(fn)\\s+([A-Za-z][A-Za-z0-9]*)\\(",
+          "captures": {
+            "1": {
+              "name": "keyword.function.ralph"
+            },
+            "2": {
+              "name": "entity.name.function.ralph"
+            }
+          }
+        }
       ]
     },
     "variables": {

--- a/syntaxes/ralph.tmLanguage.json
+++ b/syntaxes/ralph.tmLanguage.json
@@ -179,7 +179,7 @@
       "patterns": [
         {
           "comment": "types",
-          "name": "entity.name.type.rust",
+          "name": "entity.name.type.ralph",
           "match": "\\b[A-Z][A-Za-z0-9]*\\b(?!!)"
         }
 


### PR DESCRIPTION
Here is  a first batch of highlighting improvement. I tried to keep it simple.
`TxContract` is not existing anymore in our node Lexer, so I removed it and replace in some place with `AssetScript`.

The inspiration for this PR is the [rust implementation](https://github.com/microsoft/vscode/blob/main/extensions/rust/syntaxes/rust.tmLanguage.json), but I simplified a bit.

I changed few name, to respect [the language grammar of text-mate](https://macromates.com/manual/en/language_grammars) (see 12.4).

The best to review the PR is to test it :) but here are screenshots of the before/after
![maim-1679568158](https://user-images.githubusercontent.com/2979182/227182079-afd3e50b-9fad-4159-b9a1-1cf83f2c4740.png)
![maim-1679568387](https://user-images.githubusercontent.com/2979182/227182082-82af3ffe-9673-4080-af6c-4f4fa76a6bb2.png)
